### PR TITLE
Added workflow to automatically create a new docker image upon a new commit

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./
-          tags: ${{ env.DOCKERHUB_REPO }}:latest
-          push: ${{ github.ref == 'refs/heads/master' }}
+          tags: ${{ env.DOCKERHUB_REPO }}
+          push: ${{ github.ref == 'refs/heads/main' }}
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,53 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Build and Publish Docker image on Docker registry
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    paths-ignore: 
+      - '*.md'
+      - 'FUNDING.yml'
+      - LICENSE
+      - '.gitattributes'
+      - '.github/workflows/docker.yml'
+      - '.dockerignore'
+      
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This job pushes a new image on every new commit to the docker hub with the tag 'nightly' and is called 'nightly'
+  nightly:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # setup Docker buld action
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build image and push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          tags: ${{ env.DOCKERHUB_REPO }}:latest
+          push: ${{ github.ref == 'refs/heads/master' }}
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./
-          tags: ${{ env.DOCKERHUB_REPO }}
+          tags: ${{ secrets.DOCKERHUB_REPO }}
           push: ${{ github.ref == 'refs/heads/main' }}
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Hi,
I added a workflow which will create a new docker image every time a new commit is pushed to the main branch. This way, you don't have to worry about pushing a new image every time, because it happens automatically. 
If you don't know what workflows are, check out this [link](https://docs.github.com/en/actions/using-workflows/about-workflows)
There are 3 secrets needed for the workflow to run. For information on how to add a repository secret, check out this [link](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-encrypted-secrets-for-your-repository-and-organization-for-codespaces)
The necessary secrets: 

- `DOCKERHUB_USERNAME`: the username for the account where the image will be pushed. In my case it's jvt038, but in yours it's probably bsyed.
- `DOCKERHUB_TOKEN`: this is the token that the workflow will use to log in to the docker hub. It can be created by going to the [docker hub security section](https://hub.docker.com/settings/security) and add a new access token with read, write and delete permissions. Copy the token and add it to your repository secrets.
- `DOCKERHUB_REPO`: this is the repo you want to push to, including the tag. In my case it was `jvt038/troddit:latest`, but in yours probably `bsyed/troddit:latest`.

