### PR TITLE
Add default comment sort order setting, refactor comment sorter

### DIFF
--- a/src/MainContext.tsx
+++ b/src/MainContext.tsx
@@ -111,6 +111,7 @@ export const MainProvider = ({ children }) => {
   const [autoPlayInterval, setAutoPlayInterval] = useState<number>();
   const [waitForVidInterval, setWaitForVidInterval] = useState<boolean>();
   const [autoPlayMode, setAutoPlayMode] = useState<boolean>();
+  const [defaultSortComments, setDefaultSortComments] = useState<string>();
   const toggleRibbonCollapseOnly = () => {
     setRibbonCollapseOnly((c) => !c);
   };
@@ -1035,6 +1036,16 @@ export const MainProvider = ({ children }) => {
           setSlowRefreshInterval(30 * 60 * 1000);
         }
       };
+      const defaultSortComments = async () => {
+        let saved = (await localForage.getItem(
+            "defaultSortComments"
+        )) as string;
+        if (typeof saved === "string") {
+            setDefaultSortComments(saved);
+        } else {
+            setDefaultSortComments("top");
+        }
+      };
       const autoPlayInterval = async () => {
         let saved = (await localForage.getItem("autoPlayInterval")) as number;
         if (typeof saved === "number" && saved >= 1) {
@@ -1124,6 +1135,7 @@ export const MainProvider = ({ children }) => {
       let refreshonfocus = refreshOnFocus();
       let fastrefreshinterval = fastRefreshInterval();
       let slowrefreshinterval = slowRefreshInterval();
+      let defaultsortcomments = defaultSortComments();
       let autoplayinterval = autoPlayInterval();
       let waitforvidinterval = waitForVidInterval();
       let uniformheights = loadUniformHeights();
@@ -1169,6 +1181,7 @@ export const MainProvider = ({ children }) => {
         refreshonfocus,
         fastrefreshinterval,
         slowrefreshinterval,
+        defaultsortcomments,
         nsfw,
         autoplay,
         hoverplay,
@@ -1264,6 +1277,11 @@ export const MainProvider = ({ children }) => {
       localForage.setItem("fastRefreshInterval", fastRefreshInterval);
     }
   }, [fastRefreshInterval]);
+  useEffect(() => {
+      if (defaultSortComments !== undefined) {
+          localForage.setItem("defaultSortComments", defaultSortComments);
+      }
+  }, [defaultSortComments]);
   useEffect(() => {
     if (refreshOnFocus !== undefined) {
       localForage.setItem("refreshOnFocus", refreshOnFocus);
@@ -1629,6 +1647,8 @@ export const MainProvider = ({ children }) => {
         setMediaMode,
         autoPlayMode,
         setAutoPlayMode,
+        defaultSortComments,
+        setDefaultSortComments,
         compactLinkPics,
         toggleCompactLinkPics,
         uniformHeights,

--- a/src/components/CommentSort.tsx
+++ b/src/components/CommentSort.tsx
@@ -7,13 +7,14 @@ import { RiBarChart2Line } from "react-icons/ri";
 import { BsCircle, BsChevronDown } from "react-icons/bs";
 import { useState, useEffect } from "react";
 import React from "react";
+import { useMainContext } from "../MainContext";
 
 function classNames(...classes) {
   return classes.filter(Boolean).join(" ");
 }
 
 // Mapping of internal key to friendly display
-const COMMENT_SORTS = {
+export const COMMENT_SORTS = {
   confidence: "Best",
   top: "Top",
   new: "New",
@@ -22,7 +23,10 @@ const COMMENT_SORTS = {
   qa: "Q&A"
 };
 
-const CommentSort = ({ updateSort, sortBy = "top" }) => {
+const CommentSort = ({ updateSort, sortBy }) => {
+  const context: any = useMainContext();
+  sortBy ??= context.defaultSortComments;
+
   const [sort, setSort] = useState(sortBy);
   //confidence (best),top,new,controversial,old,qa (Q&A)
 

--- a/src/components/CommentSort.tsx
+++ b/src/components/CommentSort.tsx
@@ -75,7 +75,7 @@ const CommentSort = ({ updateSort, sortBy }) => {
             >
               <div className="py-1">
                 {Object.entries(COMMENT_SORTS).map(([k, friendlyName]) =>
-                  <Menu.Item>
+                  <Menu.Item key={k}>
                       {({ active }) => (
                           <div
                               onClick={(e) => {

--- a/src/components/CommentSort.tsx
+++ b/src/components/CommentSort.tsx
@@ -12,8 +12,18 @@ function classNames(...classes) {
   return classes.filter(Boolean).join(" ");
 }
 
+// Mapping of internal key to friendly display
+const COMMENT_SORTS = {
+  confidence: "Best",
+  top: "Top",
+  new: "New",
+  controversial: "Controversial",
+  old: "Old",
+  qa: "Q&A"
+};
+
 const CommentSort = ({ updateSort, sortBy = "top" }) => {
-  const [sort, setsort] = useState(sortBy);
+  const [sort, setSort] = useState(sortBy);
   //confidence (best),top,new,controversial,old,qa (Q&A)
 
   return (
@@ -32,7 +42,7 @@ const CommentSort = ({ updateSort, sortBy = "top" }) => {
               <div className="flex gap-1 mr-2">
                 <span className="hidden sm:block">{"sort comments by"}</span>
                 <span className="block sm:hidden">{"sort by"}</span>
-                <span>{sort}</span>
+                <span>{COMMENT_SORTS[sort]}</span>
               </div>
               <BsChevronDown
                 className={
@@ -60,124 +70,26 @@ const CommentSort = ({ updateSort, sortBy = "top" }) => {
               }
             >
               <div className="py-1">
-                {/* Best */}
-                <Menu.Item>
-                  {({ active }) => (
-                    <div
-                      onClick={(e) => {
-                        updateSort(e, "confidence");
-                        setsort("best");
-                      }}
-                      className={classNames(
-                        active ? "bg-th-highlight" : "",
-                        "block px-4 py-1 text-sm"
+                {Object.entries(COMMENT_SORTS).map(([k, friendlyName]) =>
+                  <Menu.Item>
+                      {({ active }) => (
+                          <div
+                              onClick={(e) => {
+                                  updateSort(e, k);
+                                  setSort(k);
+                              }}
+                              className={classNames(
+                                  active ? "bg-th-highlight" : "",
+                                  "block px-4 py-1 text-sm"
+                              )}
+                          >
+                              <div className="flex flex-row items-center h-6">
+                                  <span>{friendlyName}</span>
+                              </div>
+                          </div>
                       )}
-                    >
-                      <div className="flex flex-row items-center h-6">
-                        <span> best </span>
-                      </div>
-                    </div>
-                  )}
-                </Menu.Item>
-                {/* Top */}
-                <Menu.Item>
-                  {({ active }) => (
-                    <div
-                      onClick={(e) => {
-                        updateSort(e, "top");
-                        setsort("top");
-                      }}
-                      className={classNames(
-                        active ? "bg-th-highlight" : "",
-                        "block px-4 py-1 text-sm"
-                      )}
-                    >
-                      <div className="flex flex-row items-center h-6">
-                        <span> top </span>
-                      </div>
-                    </div>
-                  )}
-                </Menu.Item>
-                {/* New */}
-                <Menu.Item>
-                  {({ active }) => (
-                    <div
-                      className="group"
-                      onClick={(e) => {
-                        updateSort(e, "new");
-                        setsort("new");
-                      }}
-                    >
-                      <div
-                        className={classNames(
-                          active ? "bg-th-highlight" : "",
-                          "block px-4 py-1 text-sm"
-                        )}
-                      >
-                        <div className="flex flex-row items-center h-6">
-                          <span> new </span>{" "}
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                </Menu.Item>
-                {/* Controversial */}
-                <Menu.Item>
-                  {({ active }) => (
-                    <div
-                      onClick={(e) => {
-                        updateSort(e, "controversial");
-                        setsort("controversial");
-                      }}
-                      className={classNames(
-                        active ? "bg-th-highlight" : "",
-                        "block px-4 py-1 text-sm"
-                      )}
-                    >
-                      <div className="flex flex-row items-center h-6">
-                        <span> controversial </span>
-                      </div>
-                    </div>
-                  )}
-                </Menu.Item>
-                {/* Old */}
-                <Menu.Item>
-                  {({ active }) => (
-                    <div
-                      onClick={(e) => {
-                        updateSort(e, "old");
-                        setsort("old");
-                      }}
-                      className={classNames(
-                        active ? "bg-th-highlight" : "",
-                        "block px-4 py-1 text-sm "
-                      )}
-                    >
-                      <div className="flex flex-row items-center h-6">
-                        <span> old </span>
-                      </div>
-                    </div>
-                  )}
-                </Menu.Item>
-                {/* Q&A */}
-                <Menu.Item>
-                  {({ active }) => (
-                    <div
-                      onClick={(e) => {
-                        updateSort(e, "qa");
-                        setsort("q & a");
-                      }}
-                      className={classNames(
-                        active ? "bg-th-highlight" : "",
-                        "block px-4 py-1 text-sm "
-                      )}
-                    >
-                      <div className="flex flex-row items-center h-6">
-                        <span> {"q & a"} </span>
-                      </div>
-                    </div>
-                  )}
-                </Menu.Item>
+                  </Menu.Item>
+                )}
               </div>
             </Menu.Items>
           </Transition>

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -7,7 +7,7 @@ const Comments = ({
   comments,
   readTime,
   containerRef,
-  sort = "top",
+  sort,
   depth = 0,
   op = "",
   portraitMode = false,
@@ -18,6 +18,8 @@ const Comments = ({
 }) => {
   const { data: session, status } = useSession();
   const context: any = useMainContext();
+  sort ??= context.defaultSortComments;
+
   const [commentsData, setCommentsData] = useState<any[]>();
   useEffect(() => {
     comments && setCommentsData(comments);

--- a/src/components/PostModal.tsx
+++ b/src/components/PostModal.tsx
@@ -38,7 +38,7 @@ const PostModal = ({
   const [autoPlay, setAutoPlay] = useState(false);
   const [useMediaMode, setUseMediaMode] = useState(mediaMode);
   const [sort, setSort] = useState<string>(
-    (router?.query?.sort as string) ?? "top"
+    (router?.query?.sort as string) ?? context.defaultSortComments
   );
   const [curPost, setCurPost] = useState<any>(postData);
   const [curPostNum, setCurPostNum] = useState(postNum);

--- a/src/components/Thread.tsx
+++ b/src/components/Thread.tsx
@@ -47,7 +47,7 @@ import { MdOutlineCompress, MdOutlineExpand } from "react-icons/md";
 
 const Thread = ({
   permalink,
-  sort = "top",
+  sort,
   updateSort,
   initialData,
   setMediaMode,
@@ -59,6 +59,8 @@ const Thread = ({
   setCurPost,
 }) => {
   const context: any = useMainContext();
+  sort ??= context.defaultCommentSort;
+
   const { data: session, status } = useSession();
   const { thread } = useThread(permalink, sort, undefined, withContext);
   const [windowWidth, windowHeight] = useWindowSize();

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -21,6 +21,7 @@ import ColumnCardOptions from "./ColumnCardOptions";
 import FilterEntities from "./FilterEntities";
 import History from "./History";
 import IntInput from "./IntInput";
+import SortSelector from "./SortSelector";
 import ThemeSelector from "./ThemeSelector";
 import Toggles from "./Toggles";
 
@@ -211,6 +212,18 @@ const Settings = () => {
             />
           )
         ),
+        <label
+            key={"defaultSortComments"}
+            className="flex flex-row items-center justify-between w-full p-2 my-2 hover:cursor-pointer"
+        >
+            <span className="flex flex-col gap-0.5">
+                <span>Default Comment Sort Order</span>
+                <span className="mr-2 text-xs opacity-70">Default Sort Order for Comments on Posts</span>
+            </span>
+            <div className="flex-none w-24">
+                <SortSelector mode="comments" />
+            </div>
+        </label>,
       ],
     },
 

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -162,6 +162,18 @@ const Settings = () => {
             }
           />
         )),
+        <label
+            key={"defaultSortComments"}
+            className="flex flex-row items-center justify-between w-full p-2 my-2 hover:cursor-pointer"
+        >
+            <span className="flex flex-col gap-0.5">
+                <span>Default Comment Sort</span>
+                <span className="mr-2 text-xs opacity-70">Default sort order for Comments on Posts</span>
+            </span>
+            <div className="flex-none w-24">
+                <SortSelector mode="comments" />
+            </div>
+        </label>,
       ],
     },
     Filters: {
@@ -212,18 +224,6 @@ const Settings = () => {
             />
           )
         ),
-        <label
-            key={"defaultSortComments"}
-            className="flex flex-row items-center justify-between w-full p-2 my-2 hover:cursor-pointer"
-        >
-            <span className="flex flex-col gap-0.5">
-                <span>Default Comment Sort Order</span>
-                <span className="mr-2 text-xs opacity-70">Default Sort Order for Comments on Posts</span>
-            </span>
-            <div className="flex-none w-24">
-                <SortSelector mode="comments" />
-            </div>
-        </label>,
       ],
     },
 

--- a/src/components/settings/SortSelector.tsx
+++ b/src/components/settings/SortSelector.tsx
@@ -1,0 +1,90 @@
+import { Menu, Transition } from "@headlessui/react";
+import { COMMENT_SORTS } from "../CommentSort.tsx";
+import { useMainContext } from "../../MainContext";
+import React, { Fragment, useEffect, useState } from "react";
+
+// This module borrows heavily from ThemeSelector.tsx
+// It would be ideal to refactor the two files and create a generic Selector
+// menu for the settings screen that could be reused.
+
+function classNames(...classes) {
+  return classes.filter(Boolean).join(" ");
+}
+
+const SortSelector = (mode: "posts" | "comments") => {
+  const context: any = useMainContext();
+
+  let SORTS, sort, setSort;
+
+  if (mode === "posts") {
+    throw Error("Not implemented")
+    /* TODO: Implement default post sort order
+    SORTS = POST_SORTS;
+    sort = context.defaultSortPosts;
+    setSort = context.setDefaultSortPosts.bind(context);
+    */
+  } else {
+    SORTS = COMMENT_SORTS;
+    sort = context.defaultSortComments;
+    setSort = context.setDefaultSortComments.bind(context);
+  }
+
+  let sortFriendlyName = SORTS[sort];
+
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+  return (
+    <Menu as={"div"} className="relative w-full">
+      <Menu.Button
+        aria-label="options"
+        title={"options"}
+        name="Options"
+        className="w-full py-2 capitalize border rounded-md focus:outline-none hover:bg-th-highlight border-th-border hover:border-th-borderHighlight"
+      >
+        {mounted ? sortFriendlyName : ""}
+      </Menu.Button>
+      <Transition
+        as={Fragment}
+        enter="transition ease-out duration-100"
+        enterFrom="transform opacity-0 scale-95"
+        enterTo="transform opacity-100 scale-100"
+        leave="transition ease-in duration-75"
+        leaveFrom="transform opacity-100 scale-100"
+        leaveTo="transform opacity-0 scale-95"
+      >
+        <Menu.Items
+          className={
+            "absolute z-10 right-0 mt-1 py-2 w-full origin-top   rounded-md shadow-lg ring-1 ring-th-base ring-opacity-5 focus:outline-none border border-th-border bg-th-background2 "
+          }
+        >
+          {Object.entries(SORTS).map(([key, friendlyName]) => (
+            <Menu.Item key={key}>
+              {({ active, disabled }) => (
+                <div
+                  className={classNames(
+                    active ? "bg-th-highlight " : "",
+                    "block px-4 py-2 text-sm cursor-pointer",
+                    disabled ? "hidden" : ""
+                  )}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setSort(key);
+                  }}
+                >
+                  <div className="flex flex-row items-center justify-center h-6 capitalize">
+                    {friendlyName}
+                  </div>
+                </div>
+              )}
+            </Menu.Item>
+
+          ))}
+        </Menu.Items>
+      </Transition>
+    </Menu>
+  );
+};
+
+export default SortSelector;


### PR DESCRIPTION
Partially addresses https://github.com/burhan-syed/troddit/issues/146 by adding a Default Comment Sort Order setting with a dropdown.

Default post sort order is more involved, due to the nested `range` parameter within the Top sort setting. I've started with comments since they're simpler.

The settings code should be extensible to adding default post sort order in future, though the menu will either need nesting or the range displayed in the main list.

`SortSelector.tsx` borrows heavily from the existing `ThemeSelector.tsx`. There is an opportunity to refactor the two to make a generic settings selector. I have not had time to implement this so have left a comment in the new `SortSelector.tsx` file.

Manual tests run:
* Checked that selecting a default sort order in settings correctly sets the default in comment threads.
* Checked that specifying a sort order on a post's comments does not override the default setting.
* Cleared localstorage/cookies and confirmed that the sort order persists between sessions.
* Created a session with the code on master then checked out the new code. Confirmed that the default Top comment sort order is preserved and no corruption of existing sessions occur.

<img width="787" alt="Screenshot 2023-01-29 at 23 45 37" src="https://user-images.githubusercontent.com/204647/215363506-e3c2b7fe-eab4-45b1-b77c-854d03c8d643.png">
