### PR TITLE
Add support for automatically expanding images in comments

### DIFF
--- a/src/MainContext.tsx
+++ b/src/MainContext.tsx
@@ -110,6 +110,7 @@ export const MainProvider = ({ children }) => {
   const [disableEmbeds, setDisableEmbeds] = useState<boolean>();
   const [preferEmbeds, setPreferEmbeds] = useState<boolean>();
   const [embedsEverywhere, setEmbedsEveryWhere] = useState<boolean>();
+  const [expandImages, setExpandImages] = useState<boolean>();
 
   const [autoRefreshFeed, setAutoRefreshFeed] = useState<boolean>();
   const [autoRefreshComments, setAutoRefreshComments] = useState<boolean>();
@@ -186,6 +187,9 @@ export const MainProvider = ({ children }) => {
       }
       return !e;
     });
+  };
+  const toggleExpandImages = () => {
+    setExpandImages((i) => !i);
   };
   const toggleAutoHideNav = () => {
     setAutoHideNav((p) => !p);
@@ -1004,7 +1008,10 @@ export const MainProvider = ({ children }) => {
         let saved = await localForage.getItem("embedsEverywhere");
         saved === true ? setEmbedsEveryWhere(true) : setEmbedsEveryWhere(false);
       };
-
+      const loadExpandImages = async () => {
+        let saved = await localForage.getItem("expandImages");
+        saved === true ? setExpandImages(true) : setExpandImages(false);
+      };
       const autoRefreshFeed = async () => {
         let saved = await localForage.getItem("autoRefreshFeed");
         saved === true ? setAutoRefreshFeed(true) : setAutoRefreshFeed(false);
@@ -1183,6 +1190,7 @@ export const MainProvider = ({ children }) => {
       let disableembeds = loadDisableEmbeds();
       let preferembeds = loadPreferEmbeds();
       let loadembedseverywhere = loadEmbedsEverywhere();
+      let expandImages = loadExpandImages();
       await Promise.all([
         autoplayinterval,
         waitforvidinterval,
@@ -1225,6 +1233,7 @@ export const MainProvider = ({ children }) => {
         disableembeds,
         preferembeds,
         loadembedseverywhere,
+        expandImages,
         autohidenav,
       ]);
 
@@ -1332,6 +1341,11 @@ export const MainProvider = ({ children }) => {
       localForage.setItem("embedsEverywhere", embedsEverywhere);
     }
   }, [embedsEverywhere]);
+  useEffect(() => {
+    if (expandImages !== undefined) {
+      localForage.setItem("expandImages", expandImages);
+    }
+  }, [expandImages]);
   useEffect(() => {
     if (autoSeen !== undefined) {
       localForage.setItem("autoSeen", autoSeen);
@@ -1637,6 +1651,8 @@ export const MainProvider = ({ children }) => {
         togglePreferEmbeds,
         embedsEverywhere,
         toggleEmbedsEverywhere,
+        expandImages,
+        toggleExpandImages,
         updateFilters,
         setUpdateFilters,
         applyFilters,

--- a/src/components/ParseATag.tsx
+++ b/src/components/ParseATag.tsx
@@ -2,11 +2,13 @@
 import Image from "next/legacy/image";
 import React, { useEffect, useState } from "react";
 import { CgArrowsExpandDownRight, CgArrowsExpandUpLeft } from "react-icons/cg";
+import { useMainContext } from "../MainContext";
 
 const ParseATag = (props) => {
+  const context: any = useMainContext();
   const [link, setLink] = useState("");
   const [expandable, setExpandable] = useState(false);
-  const [expand, setExpand] = useState(false);
+  const [expand, setExpand] = useState(context.expandImages);
   const [linkText, setLinkText] = useState(props?.children?.data);
   useEffect(() => {
     const checkSupport = (link: string) => {

--- a/src/components/ParseATag.tsx
+++ b/src/components/ParseATag.tsx
@@ -17,8 +17,8 @@ const ParseATag = (props) => {
 
       let imgurRegex = /([A-z.]+\.)?(imgur(\.com))+(\/)+([A-z0-9]){7}\./gm;
       let redditRegex =
-        /(preview+\.)+(reddit(\.com)|redd(\.it))+(\/[A-z0-9]+)+(\.(png|jpg))\./gm;
-      let greedyRegex = /(\.(png|jpg))/gm;
+        /(preview+\.)+(reddit(\.com)|redd(\.it))+(\/[A-z0-9]+)+(\.(png|jpg|jpeg))\./gm;
+      let greedyRegex = /(\.(png|jpg|jpeg))/gm;
       return !!(
         link.match(imgurRegex) ||
         link.match(redditRegex) ||

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -119,6 +119,7 @@ const Settings = () => {
           "disableEmbeds",
           "preferEmbeds",
           "embedsEverywhere",
+          "expandImages",
           "autoplay",
           "hoverplay",
           "audioOnHover",

--- a/src/components/settings/Toggles.tsx
+++ b/src/components/settings/Toggles.tsx
@@ -43,6 +43,7 @@ interface ToggleProps {
     | "disableEmbeds"
     | "preferEmbeds"
     | "embedsEverywhere"
+    | "expandImages"
     | "userPostType"
     | "autoRefreshFeed"
     | "autoRefreshComments"
@@ -303,6 +304,13 @@ const Toggles = ({
             "By default embeds will only show in single column view or in a post thread. Enable this to show embeds in multi-column mode. Note, this is disabled by default for better performance."
           );
         break;
+      case "expandImages":
+          !label && setSwitchLabel("Expand Images");
+          !subtext &&
+            setSwitchSubtext(
+              "Automatically expand images on comments"
+            );
+          break;
       case "userPostType":
         setIsChecked(context?.[setting] === "links");
         setCheckedIcon(<BiDetail />);
@@ -460,6 +468,9 @@ const Toggles = ({
         break;
       case "embedsEverywhere":
         context.toggleEmbedsEverywhere();
+        break;
+      case "expandImages":
+        context.toggleExpandImages();
         break;
       case "userPostType":
         context.toggleUserPostType();

--- a/src/hooks/useParseBodyHTML.tsx
+++ b/src/hooks/useParseBodyHTML.tsx
@@ -63,7 +63,15 @@ const useParseBodyHTML = ({ rawHTML, newTabLinks = false }) => {
     const blankTargets = (str) => {
       if (str?.includes("<a ")) {
         str = str?.replaceAll("<a ", '<a target="_blank" rel="noreferrer" ');
+      
+        // Check for links referencing https://preview.redd.it or https://preview.reddit.com and replace with img tags
+        const previewRedditRegex = /<a [^>]*href="https:\/\/preview\.(redd\.it|reddit\.com)\/([^"]+)"[^>]*>(.*?)<\/a>/g;
+
+        str = str.replace(previewRedditRegex, (match, domain, path) => {
+          return `<img src="https://preview.${domain}/${path}" alt="Image from preview.${domain}" />`;
+        });
       }
+
       return str;
     };
 

--- a/src/hooks/useParseBodyHTML.tsx
+++ b/src/hooks/useParseBodyHTML.tsx
@@ -44,8 +44,8 @@ const checkSupport = (link: string, node: any) => {
 
   let imgurRegex = /([A-z.]+\.)?(imgur(\.com))+(\/)+([A-z0-9]){7}\./gm;
   let redditRegex =
-    /(preview+\.)+(reddit(\.com)|redd(\.it))+(\/[A-z0-9]+)+(\.(png|jpg))\./gm;
-  let greedyRegex = /(\.(png|jpg))/gm;
+    /(preview+\.)+(reddit(\.com)|redd(\.it))+(\/[A-z0-9]+)+(\.(png|jpg|jpeg))\./gm;
+  let greedyRegex = /(\.(png|jpg|jpeg))/gm;
   return !!(
     link.match(imgurRegex) ||
     link.match(redditRegex) ||
@@ -63,13 +63,6 @@ const useParseBodyHTML = ({ rawHTML, newTabLinks = false }) => {
     const blankTargets = (str) => {
       if (str?.includes("<a ")) {
         str = str?.replaceAll("<a ", '<a target="_blank" rel="noreferrer" ');
-      
-        // Check for links referencing https://preview.redd.it or https://preview.reddit.com and replace with img tags
-        const previewRedditRegex = /<a [^>]*href="https:\/\/preview\.(redd\.it|reddit\.com)\/([^"]+)"[^>]*>(.*?)<\/a>/g;
-
-        str = str.replace(previewRedditRegex, (match, domain, path) => {
-          return `<img src="https://preview.${domain}/${path}" alt="Image from preview.${domain}" />`;
-        });
       }
 
       return str;


### PR DESCRIPTION
Add a toggle to the settings under the Media section to enable automatically expanding images in comments.

<img width="555" alt="image" src="https://github.com/user-attachments/assets/a9b0c8e2-169c-45ad-88e6-cdb3d0888707" />
